### PR TITLE
Remove quotes around (i)like value matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "yarn test:unit --watch",
     "preversion": "yarn test",
     "version": "node ./scripts/ci/release.js",
-    "postversion": "git push --tags && git push origin HEAD"
+    "postversion": "git push --tags && git push origin HEAD",
+    "prepare": "yarn build"
   },
   "dependencies": {
     "axios": "0.19.2"

--- a/src/Postgrester.ts
+++ b/src/Postgrester.ts
@@ -288,11 +288,11 @@ const Postgrester: PostgresterConstructor = class Postgrester implements Postgre
     const mayBeNot = this.isNot ? "not." : "";
 
     if (this.isAnd) {
-      this.ands.push(`${column}.like."*${value}*"`);
+      this.ands.push(`${column}.like.*${value}*`);
     } else if (this.isOr) {
-      this.ors.push(`${column}.like."*${value}*"`);
+      this.ors.push(`${column}.like.*${value}*`);
     } else {
-      this.queries.push(`${column}=${mayBeNot}like."*${value}*"`);
+      this.queries.push(`${column}=${mayBeNot}like.*${value}*`);
       this.isNot = false;
     }
 
@@ -303,11 +303,11 @@ const Postgrester: PostgresterConstructor = class Postgrester implements Postgre
     const mayBeNot = this.isNot ? "not." : "";
 
     if (this.isAnd) {
-      this.ands.push(`${column}.ilike."*${value}*"`);
+      this.ands.push(`${column}.ilike.*${value}*`);
     } else if (this.isOr) {
-      this.ors.push(`${column}.ilike."*${value}*"`);
+      this.ors.push(`${column}.ilike.*${value}*`);
     } else {
-      this.queries.push(`${column}=${mayBeNot}ilike."*${value}*"`);
+      this.queries.push(`${column}=${mayBeNot}ilike.*${value}*`);
       this.isNot = false;
     }
 


### PR DESCRIPTION
This should fix the issue mentioned in https://github.com/SocialGouv/postgrester/issues/91.

Did the quotes have any functionality added which might be lost with this PR?